### PR TITLE
Create defined class to perform analysis within thread (#338)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=5.1.14
+version=5.1.15
 group=com.linkedin.parseq
 org.gradle.parallel=true


### PR DESCRIPTION
When refactoring from an Anonymous class to a lambda, an infinite recursion occurred because each analysis was required to then fork and create a new analysis when it was done because it defined a new anonymous class.

This change defines the class specifically to avoid it analyzing itself. A follow up should be to filter anonymous classes unrelated to ParSeq.